### PR TITLE
remove addons directory, add addon_list.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # Godot 4+ specific ignores
 .godot/
 /android/
+addons/
 .obsidian/

--- a/addon_list.txt
+++ b/addon_list.txt
@@ -1,0 +1,2 @@
+aseperite-wizard=https://thisisvini.com/aseprite-wizard/en/9.x-4/introduction/index.html#sp-instalation
+


### PR DESCRIPTION
Addons are very large, and often alter editor settings, or have OS 
dependant modules. Let's use a list of project plugins that each user
can manage and not share the plugin directory so as to preserve 
individual editor preferences, environment, and keep the repo size down.